### PR TITLE
Fixed regex to parse MQTT errors

### DIFF
--- a/endpoints/mqtt.py
+++ b/endpoints/mqtt.py
@@ -118,7 +118,7 @@ class MqttWriter:
                     self.__port,
                 )
             except aiomqtt.MqttError as exc:
-                error = re.search(r"^\[Errno (\d+)\]", str(exc))
+                error = re.search(r"\[Errno (\d+)]", str(exc))
                 if error is not None:
                     error_code = int(error.group(1))
                     if error_code == 111:


### PR DESCRIPTION
Fixed the regex that parses the MQTT error messages by removing the the caret. The error code can also appear in the middle of the string.